### PR TITLE
Support for tokens as command line arguments

### DIFF
--- a/bugswarm/client/bugswarm.py
+++ b/bugswarm/client/bugswarm.py
@@ -5,7 +5,7 @@ import os
 import click
 
 from bugswarm.common import log
-from bugswarm.common import rest_api as bugswarmapi
+from bugswarm.common.rest_api.database_api import DatabaseAPI
 
 from . import docker
 from .command import MyCommand
@@ -33,6 +33,10 @@ def cli():
               help='If enabled, artifact containers will be cleaned up automatically after use. '
                    'Disable this behavior if you want to inspect the container filesystem after use. '
                    'Enabled by default.')
+@click.option('--token',
+              type=str,
+              help='An authentication token for the BugSwarm database. '
+                   'Please visit the www.bugswarm.org/get-full-access for more information.')
 def run(image_tag, use_sandbox, pipe_stdin, rm):
     """Start an artifact container."""
     # If the script does not already have sudo privileges, then explain to the user why the password prompt will appear.
@@ -45,8 +49,15 @@ def run(image_tag, use_sandbox, pipe_stdin, rm):
 @click.option('--image-tag', required=True,
               type=str,
               help='The artifact image tag.')
-def show(image_tag):
+@click.option('--token',
+              type=str,
+              help='An authentication token for the BugSwarm database. '
+                   'Please visit the www.bugswarm.org/get-full-access for more information.')
+def show(image_tag, token):
     """Display artifact metadata."""
+    print('token is [{}]'.format(token))
+    token = token or ''
+    bugswarmapi = DatabaseAPI(token=token)
     response = bugswarmapi.find_artifact(image_tag, error_if_not_found=False)
     if not response.ok:
         log.info('No artifact metadata for image tag {}.'.format(image_tag))

--- a/bugswarm/client/bugswarm.py
+++ b/bugswarm/client/bugswarm.py
@@ -33,10 +33,6 @@ def cli():
               help='If enabled, artifact containers will be cleaned up automatically after use. '
                    'Disable this behavior if you want to inspect the container filesystem after use. '
                    'Enabled by default.')
-@click.option('--token',
-              type=str,
-              help='An authentication token for the BugSwarm database. '
-                   'Please visit the www.bugswarm.org/get-full-access for more information.')
 def run(image_tag, use_sandbox, pipe_stdin, rm):
     """Start an artifact container."""
     # If the script does not already have sudo privileges, then explain to the user why the password prompt will appear.
@@ -49,13 +45,12 @@ def run(image_tag, use_sandbox, pipe_stdin, rm):
 @click.option('--image-tag', required=True,
               type=str,
               help='The artifact image tag.')
-@click.option('--token',
+@click.option('--token', required=True,
               type=str,
               help='An authentication token for the BugSwarm database. '
-                   'Please visit the www.bugswarm.org/get-full-access for more information.')
+                   'Please visit www.bugswarm.org/get-full-access for more information.')
 def show(image_tag, token):
     """Display artifact metadata."""
-    print('token is [{}]'.format(token))
     token = token or ''
     bugswarmapi = DatabaseAPI(token=token)
     response = bugswarmapi.find_artifact(image_tag, error_if_not_found=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Click==6.7
 requests==2.18.4
 
-bugswarm-common==0.1.0
+bugswarm-common==0.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Click==6.7
 requests==2.18.4
 
-bugswarm-common==0.0.3
+bugswarm-common==0.1.0


### PR DESCRIPTION
- Adds `--token` as a required argument to the `bugswarm show` command. Provide an access token with read privileges or higher to use this command.
- Now depends on `bugswarm-common` version `0.1.1`.