### PR TITLE
Update common

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Click==6.7
-requests==2.18.4
+requests>=2.20.0
 
 bugswarm-common==0.1.12

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     install_requires=[
         'Click==6.7',
         'requests==2.18.4',
-        'bugswarm-common==0.1.10',
+        'bugswarm-common==0.1.12',
     ],
 
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 
 setup(
     name='bugswarm-client',
-    version='0.1.5',
+    version='0.1.4',
     url='https://github.com/BugSwarm/client',
     author='BugSwarm',
     author_email='dev.bugswarm@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 
 setup(
     name='bugswarm-client',
-    version='0.1.4',
+    version='0.1.5',
     url='https://github.com/BugSwarm/client',
     author='BugSwarm',
     author_email='dev.bugswarm@gmail.com',
@@ -21,7 +21,7 @@ setup(
     ],
     install_requires=[
         'Click==6.7',
-        'requests==2.18.4',
+        'requests>=2.20.0',
         'bugswarm-common==0.1.12',
     ],
 


### PR DESCRIPTION
* update common version to `0.1.12` to fix the current broken issue
* update requests to `>=2.20.0` due to vulnerability. [[see here]](https://nvd.nist.gov/vuln/detail/CVE-2018-18074). same PR in https://github.com/BugSwarm/common/pull/18

