### PR TITLE
Allow overriding DOCKER_HUB_REPO

### DIFF
--- a/bugswarm/client/bugswarm.py
+++ b/bugswarm/client/bugswarm.py
@@ -20,6 +20,9 @@ def cli():
 
 
 @cli.command(cls=MyCommand)
+@click.option('--docker-hub-repo', default=None,
+              type=str,
+              help='Override the default Docker Hub repo (bugswarm/images)')
 @click.option('--image-tag', required=True,
               type=str,
               help='The artifact image tag.')
@@ -33,12 +36,12 @@ def cli():
               help='If enabled, artifact containers will be cleaned up automatically after use. '
                    'Disable this behavior if you want to inspect the container filesystem after use. '
                    'Enabled by default.')
-def run(image_tag, use_sandbox, pipe_stdin, rm):
+def run(docker_hub_repo, image_tag, use_sandbox, pipe_stdin, rm):
     """Start an artifact container."""
     # If the script does not already have sudo privileges, then explain to the user why the password prompt will appear.
     if os.getuid() != 0:
         log.info('Docker requires sudo privileges.')
-    docker.docker_run(image_tag, use_sandbox, pipe_stdin, rm)
+    docker.docker_run(docker_hub_repo, image_tag, use_sandbox, pipe_stdin, rm)
 
 
 @cli.command(cls=MyCommand)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 
 setup(
     name='bugswarm-client',
-    version='0.1.6',
+    version='0.1.7',
     url='https://github.com/BugSwarm/client',
     author='BugSwarm',
     author_email='dev.bugswarm@gmail.com',


### PR DESCRIPTION
Allow the user to change `DOCKER_HUB_REPO` by `--docker-hub-repo` instead of modifying something like `~/.local/lib/python3.?/site-packages/bugswarm/common/credentials.py`
Close #7 