### PR TITLE
Update to use cached-images repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ $ pip3 install bugswarm-client
 ## Usage
 See [this documentation page](http://www.bugswarm.org/docs/toolset/bugswarm-cli).
 
+Please note that artifacts are first attempted to be pulled from `bugswarm/cached-images`, and if not found then they are attempted to be pulled from `bugswarm/images`.
+
 ## Development
 Execute the following commands to install the tool in ["editable" mode](https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs).
 1. Clone this repository.


### PR DESCRIPTION
Updates `DOCKERHUB_REPO` to `DOCKERHUB_CACHED_REPO` and adds a note about the repo to the `README`.

Continuation of https://github.com/BugSwarm/client/pull/10 which was on a fork before I had write permissions to this repo.

Tested:

not in cached-images:
```
(test-client-env) rjae@ad3.ucdavis.edu@cobalt:~/client$ bugswarm run --image-tag stagemonitor-stagemonitor-253536495
[WARNING]: DOCKER_REGISTRY_REPO has not been found. Skip pushing to docker private registry in reproducing stage
[WARNING]: DOCKER_REGISTRY_USERNAME has not been found. Skip pushing to docker private registry in reproducing stage
[WARNING]: DOCKER_REGISTRY_PASSWORD has not been found. Skip pushing to docker private registry in reproducing stage
[    INFO] --- Docker requires sudo privileges.
Error response from daemon: manifest for bugswarm/cached-images:stagemonitor-stagemonitor-253536495 not found: manifest unknown: manifest unknown
stagemonitor-stagemonitor-253536495: Pulling from bugswarm/images
Digest: sha256:a69a2d6195b06df81bebbf4b798b748cd25e351f1ff32c3609f558a63c04f6fb
Status: Image is up to date for bugswarm/images:stagemonitor-stagemonitor-253536495
docker.io/bugswarm/images:stagemonitor-stagemonitor-253536495
[    INFO] --- Downloaded the image bugswarm/images:stagemonitor-stagemonitor-253536495.
[    INFO] --- Entering the container.
[    INFO] --- The container will be cleaned up after use.
sudo docker run --privileged --rm -i -t bugswarm/images:stagemonitor-stagemonitor-253536495 /bin/bash
```
In cached-images:
```
(test-client-env) rjae@ad3.ucdavis.edu@cobalt:~/client$ bugswarm run --image-tag UNC-Libraries-Carolina-Digital-Repository-382144611
[WARNING]: DOCKER_REGISTRY_REPO has not been found. Skip pushing to docker private registry in reproducing stage
[WARNING]: DOCKER_REGISTRY_USERNAME has not been found. Skip pushing to docker private registry in reproducing stage
[WARNING]: DOCKER_REGISTRY_PASSWORD has not been found. Skip pushing to docker private registry in reproducing stage
[    INFO] --- Docker requires sudo privileges.
UNC-Libraries-Carolina-Digital-Repository-382144611: Pulling from bugswarm/cached-images
01a4f8387457: Already exists 
c887940e680c: Already exists 
5432573ac160: Already exists 
027ee9a9665e: Already exists 
5611db80430d: Already exists 
9c60dc18859b: Already exists 
db89620bb9ce: Already exists 
a26fee296996: Already exists 
16e5969a1d86: Already exists 
dc9188d63ac4: Already exists 
68f396623e9f: Already exists 
77b54a696938: Already exists 
45e976717f2c: Already exists 
b32f28e62303: Already exists 
de836ecc3375: Already exists 
14dbf3836ddb: Already exists 
7632080a46a2: Already exists 
0056dde29023: Already exists 
28f09b0c5fd6: Pull complete 
e5d75c7d22ec: Pull complete 
28d5fc26b7dd: Pull complete 
463535b40cf3: Pull complete 
a5fafb9943a8: Pull complete 
8b1b2d97dda4: Pull complete 
c0d9862c9acd: Pull complete 
ccd8cdea3df9: Pull complete 
e203b88bf5df: Pull complete 
82fc4ab33794: Pull complete 
1c50c124af9c: Pull complete 
47fd2ff70ac0: Pull complete 
e6fdbac86a5b: Pull complete 
efbf03f2ca96: Pull complete 
c41cc2c5b361: Pull complete 
212a90c11e49: Pull complete 
009616505ce6: Pull complete 
bcdf7fcd56a6: Pull complete 
dcbcc480095d: Pull complete 
Digest: sha256:ee71ae68e4ec036c446fa494965662813d4246acbe37eed78e55a8ca6989bd6f
Status: Downloaded newer image for bugswarm/cached-images:UNC-Libraries-Carolina-Digital-Repository-382144611
docker.io/bugswarm/cached-images:UNC-Libraries-Carolina-Digital-Repository-382144611
[    INFO] --- Downloaded the image bugswarm/cached-images:UNC-Libraries-Carolina-Digital-Repository-382144611.
[    INFO] --- Entering the container.
[    INFO] --- The container will be cleaned up after use.
```