### PR TITLE
Fix README and docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,50 @@ $ pip3 install bugswarm-client
 ```
 
 ## Usage
-See [this documentation page](http://www.bugswarm.org/docs/toolset/bugswarm-cli).
+Download a Docker image and enter the Docker container associated with an artifact.
+```shell
+$ bugswarm run --image-tag <image_tag>
+```
+> Depending on how Docker is configured on your machine, you may need to enter an administrator password.
+
+Download a Docker image and enter the Docker container with a shared folder between the container and the host machine.
+
+```shell
+$ bugswarm run --image-tag <image_tag> --use-sandbox
+```
+
+Show metadata for an artifact.
+
+```shell
+$ bugswarm show --image-tag <image_tag> --token <token>
+```
+
+Show usage text for the entire tool or for a specific sub-command.
+
+```shell
+$ bugswarm --help
+$ bugswarm <sub-command> --help
+```
+
+Show the version.
+
+```shell
+$ bugswarm --version
+```
 
 Please note that artifacts are first attempted to be pulled from `bugswarm/cached-images`, and if not found then they are attempted to be pulled from `bugswarm/images`.
 
+## Example
+
+```shell
+$ bugswarm run --image-tag nutzam-nutz-140438299
+$ bugswarm show --image-tag nutzam-nutz-140438299 --token <token>
+```
+
+> [Requires a token](http://www.bugswarm.org/contact/)
+
 ## Development
-Execute the following commands to install the tool in ["editable" mode](https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs).
+Execute the following commands to install the tool in ["editable" mode](https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs).
 1. Clone this repository.
     ```
     $ git clone https://github.com/BugSwarm/client.git
@@ -27,5 +65,5 @@ Execute the following commands to install the tool in ["editable" mode](https://
     ```
 1. Install the tool.
     ```
-    $ pip3 install --upgrade --force-reinstall --process-dependency-links -e .
+    $ pip3 install --upgrade --force-reinstall -e .
     ```

--- a/bugswarm/client/docker.py
+++ b/bugswarm/client/docker.py
@@ -3,12 +3,17 @@ import subprocess
 import sys
 
 from bugswarm.common import log
-from bugswarm.common.credentials import DOCKER_HUB_REPO, DOCKER_HUB_CACHED_REPO
 from bugswarm.common.shell_wrapper import ShellWrapper
+import bugswarm.common.credentials as credentials
 
 SCRIPT_DEFAULT = '/bin/bash'
 HOST_SANDBOX_DEFAULT = '~/bugswarm-sandbox'
 CONTAINER_SANDBOX_DEFAULT = '/bugswarm-sandbox'
+
+DOCKER_HUB_REPO = \
+    credentials.DOCKER_HUB_REPO if hasattr(credentials, 'DOCKER_HUB_REPO') else 'bugswarm/images'
+DOCKER_HUB_CACHED_REPO = \
+    credentials.DOCKER_HUB_CACHED_REPO if hasattr(credentials, 'DOCKER_HUB_CACHED_REPO') else 'bugswarm/cached-images'
 
 
 # By default, this function downloads the image, enters the container, and executes '/bin/bash' in the container.
@@ -80,7 +85,7 @@ def docker_pull(image_tag):
 
     # Exit early if the image already exists locally.
     if _image_exists_locally(image_tag):
-        return True
+        return True, _image_location(image_tag)
 
     image_location = _image_location(image_tag)
     command = 'sudo docker pull {}'.format(image_location)

--- a/bugswarm/client/docker.py
+++ b/bugswarm/client/docker.py
@@ -106,7 +106,7 @@ def docker_pull(image_tag):
     return returncode == 0, image_location
 
 
-# Returns True if the image already exists locally.
+# Returns True and image_location if the image already exists locally.
 def _docker_image_inspect(image_tag):
     image_location = _image_location(image_tag)
     command = 'sudo docker image inspect {}'.format(image_location)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 
 setup(
     name='bugswarm-client',
-    version='0.1.6',
+    version='0.1.7',
     url='https://github.com/BugSwarm/client',
     author='BugSwarm',
     author_email='dev.bugswarm@gmail.com',


### PR DESCRIPTION
Check if `DOCKER_HUB_CACHED_REPO` is in credentials, if not, use default value `bugswarm/cached-images`.
Run `bugswarm run --image-tag image_tag` twice will work properly now.